### PR TITLE
Include the sdk dir in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 *
 !bundle/*
 !lib/*
+!lib/sdk/*
 !package.json
 !README.md
 !LICENSE


### PR DESCRIPTION
Include the `/lib/sdk` in the npm package, to support non-web TypeScript deployments. 