### PR TITLE
Fix `bytesToNumber()`

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,23 @@
+import { numberToBytes, bytesToNumber } from './utils';
+
+describe('decrypt', () => {
+  it('converts a number to bytes', async () => {
+    const value = 28482;
+    const bytes = numberToBytes(value);
+    expect(bytes).toEqual(new Uint8Array([111, 66]));
+
+    const value2 = 255;
+    const bytes2 = numberToBytes(value2);
+    expect(bytes2).toEqual(new Uint8Array([255]));
+  });
+
+  it('converts bytes to number', async () => {
+    const value = new Uint8Array([23, 200, 15]);
+    const bytes = bytesToNumber(value);
+    expect(bytes).toBe(1558543);
+
+    const value2 = new Uint8Array();
+    const bytes2 = bytesToNumber(value2);
+    expect(bytes2).toBe(0);
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,14 +21,13 @@ export const numberToBytes = (uint32Value: number) => {
   return byteArray;
 };
 
-export const bytesToNumber = (byteArray: Uint8Array): number => {
-  let uint32Value = 0;
+export const bytesToNumber = function (byteArray: Uint8Array): number {
+  const length = byteArray.length;
 
-  for (let i = 0; i < byteArray.length; i++) {
-    uint32Value |= byteArray[i] << (8 * (byteArray.length - 1 - i));
-  }
+  const buffer = Buffer.from(byteArray);
+  const result = buffer.readUIntBE(0, length);
 
-  return uint32Value;
+  return result;
 };
 
 export const isAddress = function (address: string) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,6 +22,10 @@ export const numberToBytes = (uint32Value: number) => {
 };
 
 export const bytesToNumber = function (byteArray: Uint8Array): number {
+  if (!byteArray || byteArray?.length === 0) {
+    return 0;
+  }
+
   const length = byteArray.length;
 
   const buffer = Buffer.from(byteArray);


### PR DESCRIPTION
This fixes `bytesToNumber()` to always return the result as an unsigned integer.

Example: `byteArray` holds the value `2^32 - 3`, which is `11111111111111111111111111111101` in binary. The old implementation uses the `number` type, which is a signed integer, to calculate intermediate values. And because the most significant bit (MSB) is turned on, it interprets this as a negative number and returns `-3`.