### PR TITLE
fixture(eaddress): truncate hex string from decrypted bytes (leading 00)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fhevmjs",
-  "version": "0.4.0-8",
+  "version": "0.4.0-9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fhevmjs",
-      "version": "0.4.0-8",
+      "version": "0.4.0-9",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "bigint-buffer": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fhevmjs",
-  "version": "0.4.0-8",
+  "version": "0.4.0-9",
   "description": "fhEVM SDK for blockchain using TFHE",
   "main": "lib/node.cjs",
   "types": "lib/node.d.ts",

--- a/src/sdk/decrypt.test.ts
+++ b/src/sdk/decrypt.test.ts
@@ -59,7 +59,7 @@ describe('decrypt', () => {
     expect(cleartext).toBe(getAddress(expected));
   });
 
-  it.only('decrypts an address Uint8Array value lower than 160 bits', async () => {
+  it('decrypts an address Uint8Array value lower than 160 bits', async () => {
     const keypair = sodium.crypto_box_keypair();
     const address = '0x8ba1f109551bd432803012645ac136ddd64d'
     // Must add padding until to 40-digit

--- a/src/sdk/decrypt.test.ts
+++ b/src/sdk/decrypt.test.ts
@@ -44,4 +44,32 @@ describe('decrypt', () => {
     const cleartext = decryptAddress(keypair, ciphertext);
     expect(cleartext).toBe(getAddress(value.toString(16)));
   });
+
+  it('decrypts an address Uint8Array value bigger than 160 bits', async () => {
+    const keypair = sodium.crypto_box_keypair();
+    const address = '0x9b8a8ba1f109551bd432803012645ac136ddd64dba72'
+    // Must truncate to 40-digit
+    const expected = '0x8ba1f109551bd432803012645ac136ddd64dba72'
+    const value = BigInt(address);
+    const ciphertext = sodium.crypto_box_seal(
+      bigIntToBytes(value),
+      keypair.publicKey,
+    );
+    const cleartext = decryptAddress(keypair, ciphertext);
+    expect(cleartext).toBe(getAddress(expected));
+  });
+
+  it.only('decrypts an address Uint8Array value lower than 160 bits', async () => {
+    const keypair = sodium.crypto_box_keypair();
+    const address = '0x8ba1f109551bd432803012645ac136ddd64d'
+    // Must add padding until to 40-digit
+    const expected = '0x00008ba1f109551bd432803012645ac136ddd64d'
+    const value = BigInt(address);
+    const ciphertext = sodium.crypto_box_seal(
+      bigIntToBytes(value),
+      keypair.publicKey,
+    );
+    const cleartext = decryptAddress(keypair, ciphertext);
+    expect(cleartext).toBe(getAddress(expected));
+  });
 });

--- a/src/sdk/decrypt.ts
+++ b/src/sdk/decrypt.ts
@@ -35,7 +35,7 @@ let hexString = bytesToHex(decrypted);
 if (hexString.length > 40) {
   hexString = hexString.substring(hexString.length - 40);
 } else {
-  hexString = hexString.padStart(40, '0');
+  hexString = hexString.slice(2).padStart(40, '0');
 }
   return getAddress(hexString);
 };

--- a/src/sdk/decrypt.ts
+++ b/src/sdk/decrypt.ts
@@ -28,5 +28,14 @@ export const decryptAddress = (
     keypair.publicKey,
     keypair.privateKey,
   );
-  return getAddress(bytesToHex(decrypted));
+
+let hexString = bytesToHex(decrypted);
+// Ensure hexString forms a valid 40-digit Ethereum address.
+// Truncate or pad with leading zeros as necessary to correct length issues.
+if (hexString.length > 40) {
+  hexString = hexString.substring(hexString.length - 40);
+} else {
+  hexString = hexString.padStart(40, '0');
+}
+  return getAddress(hexString);
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,8 +19,7 @@ export const bytesToHex = function (byteArray: Uint8Array): string {
     return '0x0';
   }
   const buffer = Buffer.from(byteArray);
-  const result = '0x' + buffer.toString('hex');
-  return result;
+  return `0x${buffer.toString('hex')}`;
 };
 
 export const bytesToBigInt = function (byteArray: Uint8Array): bigint {
@@ -30,7 +29,6 @@ export const bytesToBigInt = function (byteArray: Uint8Array): bigint {
 
   const buffer = Buffer.from(byteArray);
   const result = toBigIntBE(buffer);
-
   return result;
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,12 +18,8 @@ export const bytesToHex = function (byteArray: Uint8Array): string {
   if (!byteArray || byteArray?.length === 0) {
     return '0x0';
   }
-
-  const length = byteArray.length;
-
   const buffer = Buffer.from(byteArray);
-  const result = buffer.toString('hex');
-
+  const result = '0x' + buffer.toString('hex');
   return result;
 };
 
@@ -31,8 +27,6 @@ export const bytesToBigInt = function (byteArray: Uint8Array): bigint {
   if (!byteArray || byteArray?.length === 0) {
     return BigInt(0);
   }
-
-  const length = byteArray.length;
 
   const buffer = Buffer.from(byteArray);
   const result = toBigIntBE(buffer);


### PR DESCRIPTION
The decrypted value could contain leading 0 bytes  (e.g. KMS returns 32 bytes serialized big int). This behaviour triggers error with getAddress method from ethers which takes hex string and return eth plain address (if hexstring > 40 digits)