### PR TITLE
Fhevmjs fixes to work with local node

### DIFF
--- a/src/ethCall.ts
+++ b/src/ethCall.ts
@@ -33,6 +33,9 @@ export const fetchJSONRPC = async (url: string, options: RequestInit) => {
     if (data && data.result) {
       // The result is usually prefixed with '0x' and is in hex format
       const hexResult = data.result;
+      if (typeof hexResult == 'object') {
+        return hexResult;
+      }
       const decodedBytes = decodeAbiBytes(hexResult);
       return `0x${toHexString(decodedBytes)}`;
     } else {

--- a/src/sdk/encrypt.test.ts
+++ b/src/sdk/encrypt.test.ts
@@ -8,6 +8,8 @@ import {
 } from 'node-tfhe';
 import { createTfheKeypair } from '../tfhe';
 import { createEncryptedInput } from './encrypt';
+import { fetchJSONRPC } from '../ethCall';
+import { fromHexString } from '../utils';
 
 describe('encrypt', () => {
   let clientKey: TfheClientKey;
@@ -185,5 +187,53 @@ describe('encrypt', () => {
     expect(() => input2.encrypt()).toThrow(
       'Too many bits in provided values. Maximum is 2048.',
     );
+  });
+});
+
+describe('encryptWithCoprocessor', () => {
+  let publicKey: TfheCompactPublicKey;
+  const coprocessorNode = 'http://127.0.0.1:8745';
+
+  beforeAll(async () => {
+    const pkeyOptions = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        method: "eth_getPublicFhevmKey",
+        params: [],
+        id: 1,
+        jsonrpc: "2.0",
+      }),
+    };
+    const pkeyRes = await fetchJSONRPC(
+      coprocessorNode,
+      pkeyOptions,
+    );
+
+    publicKey = TfheCompactPublicKey.deserialize(fromHexString(pkeyRes.publicKey));
+  });
+
+  it('encrypt with coprocessor', async () => {
+    const input = createEncryptedInput(publicKey, coprocessorNode)(
+      '0x8ba1f109551bd432803012645ac136ddd64dba72',
+      '0xa5e1defb98EFe38EBb2D958CEe052410247F4c80',
+    );
+    input.addBool(BigInt(0));
+    input.add4(2);
+    input.add8(BigInt(43));
+    input.add16(BigInt(87));
+    input.add32(BigInt(2339389323));
+    input.add64(BigInt(23393893233));
+    //input.add128(BigInt(233938932390)); // 128 bits not supported yet in coprocessor
+    input.addAddress('0xa5e1defb98EFe38EBb2D958CEe052410247F4c80');
+
+    const res = await input.send();
+    expect(res.handlesList).toBeDefined();
+    expect(res.handlesList.length).toBe(7);
+    expect(res.callerAddress).toBe('0xa5e1defb98EFe38EBb2D958CEe052410247F4c80');
+    expect(res.contractAddress).toBe('0x8ba1f109551bD432803012645Ac136ddd64DBA72');
+    expect(res.signature).toBeDefined();
   });
 });

--- a/src/sdk/encrypt.test.ts
+++ b/src/sdk/encrypt.test.ts
@@ -216,10 +216,12 @@ describe('encryptWithCoprocessor', () => {
   });
 
   it('encrypt with coprocessor', async () => {
+    // encrypted inputs, we pass coprocessor node url
     const input = createEncryptedInput(publicKey, coprocessorNode)(
       '0x8ba1f109551bd432803012645ac136ddd64dba72',
       '0xa5e1defb98EFe38EBb2D958CEe052410247F4c80',
     );
+    // add inputs
     input.addBool(BigInt(0));
     input.add4(2);
     input.add8(BigInt(43));
@@ -229,7 +231,9 @@ describe('encryptWithCoprocessor', () => {
     //input.add128(BigInt(233938932390)); // 128 bits not supported yet in coprocessor
     input.addAddress('0xa5e1defb98EFe38EBb2D958CEe052410247F4c80');
 
+    // send to the coprocessor
     const res = await input.send();
+    // receive handlesList, callerAddress, contractAddress and EIP712 signature
     expect(res.handlesList).toBeDefined();
     expect(res.handlesList.length).toBe(7);
     expect(res.callerAddress).toBe('0xa5e1defb98EFe38EBb2D958CEe052410247F4c80');

--- a/src/sdk/encrypt.test.ts
+++ b/src/sdk/encrypt.test.ts
@@ -190,54 +190,54 @@ describe('encrypt', () => {
   });
 });
 
-describe('encryptWithCoprocessor', () => {
-  let publicKey: TfheCompactPublicKey;
-  const coprocessorNode = 'http://127.0.0.1:8745';
+// describe('encryptWithCoprocessor', () => {
+//   let publicKey: TfheCompactPublicKey;
+//   const coprocessorNode = 'http://127.0.0.1:8745';
 
-  beforeAll(async () => {
-    const pkeyOptions = {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        method: "eth_getPublicFhevmKey",
-        params: [],
-        id: 1,
-        jsonrpc: "2.0",
-      }),
-    };
-    const pkeyRes = await fetchJSONRPC(
-      coprocessorNode,
-      pkeyOptions,
-    );
+//   beforeAll(async () => {
+//     const pkeyOptions = {
+//       method: 'POST',
+//       headers: {
+//         'Content-Type': 'application/json',
+//       },
+//       body: JSON.stringify({
+//         method: "eth_getPublicFhevmKey",
+//         params: [],
+//         id: 1,
+//         jsonrpc: "2.0",
+//       }),
+//     };
+//     const pkeyRes = await fetchJSONRPC(
+//       coprocessorNode,
+//       pkeyOptions,
+//     );
 
-    publicKey = TfheCompactPublicKey.deserialize(fromHexString(pkeyRes.publicKey));
-  });
+//     publicKey = TfheCompactPublicKey.deserialize(fromHexString(pkeyRes.publicKey));
+//   });
 
-  it('encrypt with coprocessor', async () => {
-    // encrypted inputs, we pass coprocessor node url
-    const input = createEncryptedInput(publicKey, coprocessorNode)(
-      '0x8ba1f109551bd432803012645ac136ddd64dba72',
-      '0xa5e1defb98EFe38EBb2D958CEe052410247F4c80',
-    );
-    // add inputs
-    input.addBool(BigInt(0));
-    input.add4(2);
-    input.add8(BigInt(43));
-    input.add16(BigInt(87));
-    input.add32(BigInt(2339389323));
-    input.add64(BigInt(23393893233));
-    //input.add128(BigInt(233938932390)); // 128 bits not supported yet in coprocessor
-    input.addAddress('0xa5e1defb98EFe38EBb2D958CEe052410247F4c80');
+//   it('encrypt with coprocessor', async () => {
+//     // encrypted inputs, we pass coprocessor node url
+//     const input = createEncryptedInput(publicKey, coprocessorNode)(
+//       '0x8ba1f109551bd432803012645ac136ddd64dba72',
+//       '0xa5e1defb98EFe38EBb2D958CEe052410247F4c80',
+//     );
+//     // add inputs
+//     input.addBool(BigInt(0));
+//     input.add4(2);
+//     input.add8(BigInt(43));
+//     input.add16(BigInt(87));
+//     input.add32(BigInt(2339389323));
+//     input.add64(BigInt(23393893233));
+//     //input.add128(BigInt(233938932390)); // 128 bits not supported yet in coprocessor
+//     input.addAddress('0xa5e1defb98EFe38EBb2D958CEe052410247F4c80');
 
-    // send to the coprocessor
-    const res = await input.send();
-    // receive handlesList, callerAddress, contractAddress and EIP712 signature
-    expect(res.handlesList).toBeDefined();
-    expect(res.handlesList.length).toBe(7);
-    expect(res.callerAddress).toBe('0xa5e1defb98EFe38EBb2D958CEe052410247F4c80');
-    expect(res.contractAddress).toBe('0x8ba1f109551bD432803012645Ac136ddd64DBA72');
-    expect(res.signature).toBeDefined();
-  });
-});
+//     // send to the coprocessor
+//     const res = await input.send();
+//     // receive handlesList, callerAddress, contractAddress and EIP712 signature
+//     expect(res.handlesList).toBeDefined();
+//     expect(res.handlesList.length).toBe(7);
+//     expect(res.callerAddress).toBe('0xa5e1defb98EFe38EBb2D958CEe052410247F4c80');
+//     expect(res.contractAddress).toBe('0x8ba1f109551bD432803012645Ac136ddd64DBA72');
+//     expect(res.signature).toBeDefined();
+//   });
+// });

--- a/src/sdk/encrypt.ts
+++ b/src/sdk/encrypt.ts
@@ -50,6 +50,21 @@ const checkEncryptedValue = (value: number | bigint, bits: number) => {
   }
 };
 
+const encTypeToCoprocessorType: Record<keyof typeof ENCRYPTION_TYPES, number> = {
+  [1]: 0,
+  [4]: 1,
+  [8]: 2,
+  [16]: 3,
+  [32]: 4,
+  [64]: 5,
+  [128]: 6,
+  [160]: 7,
+  [256]: 8,
+  [512]: 9,
+  [1024]: 10,
+  [2048]: 11,
+};
+
 export const createEncryptedInput =
   (tfheCompactPublicKey?: TfheCompactPublicKey, coprocessorUrl?: string) =>
   (contractAddress: string, callerAddress: string) => {
@@ -202,14 +217,16 @@ export const createEncryptedInput =
         const ciphertext = encrypted.serialize();
 
         const data = new Uint8Array(1 + bits.length + ciphertext.length);
-        data.set([data.length], 0);
-        data.set(bits, 1);
-        data.set(ciphertext, data.length + 1);
+        data.set([bits.length], 0);
+        bits.forEach((value, index) => {
+          data.set([encTypeToCoprocessorType[value] & 0xff], 1 + index);
+        });
+        data.set(ciphertext, bits.length + 1);
 
         const payload = {
           jsonrpc: '2.0',
           method: 'eth_addUserCiphertext',
-          params: [toHexString(data), contractAddress, callerAddress],
+          params: ['0x' + toHexString(data), contractAddress, callerAddress],
           id: 1,
         };
 
@@ -221,9 +238,7 @@ export const createEncryptedInput =
           },
           body: JSON.stringify(payload),
         };
-        const response = await fetchJSONRPC(coprocessorUrl, options);
-        if (!response) throw new Error('Invalid input');
-        return JSON.parse(response);
+        return await fetchJSONRPC(coprocessorUrl, options);
       },
     };
   };

--- a/src/sdk/encrypt.ts
+++ b/src/sdk/encrypt.ts
@@ -50,21 +50,6 @@ const checkEncryptedValue = (value: number | bigint, bits: number) => {
   }
 };
 
-const encTypeToCoprocessorType: Record<keyof typeof ENCRYPTION_TYPES, number> = {
-  [1]: 0,
-  [4]: 1,
-  [8]: 2,
-  [16]: 3,
-  [32]: 4,
-  [64]: 5,
-  [128]: 6,
-  [160]: 7,
-  [256]: 8,
-  [512]: 9,
-  [1024]: 10,
-  [2048]: 11,
-};
-
 export const createEncryptedInput =
   (tfheCompactPublicKey?: TfheCompactPublicKey, coprocessorUrl?: string) =>
   (contractAddress: string, callerAddress: string) => {
@@ -219,7 +204,7 @@ export const createEncryptedInput =
         const data = new Uint8Array(1 + bits.length + ciphertext.length);
         data.set([bits.length], 0);
         bits.forEach((value, index) => {
-          data.set([encTypeToCoprocessorType[value] & 0xff], 1 + index);
+          data.set([ENCRYPTION_TYPES[value] & 0xff], 1 + index);
         });
         data.set(ciphertext, bits.length + 1);
 


### PR DESCRIPTION
Tested with coprocessor, we need following adjustments:
1. types byte array must be made of one byte numbers, not more than 255, bit values like 2048 are too high, added encoding for fhevmjs type to node type enum
2. added `0x` in front of input hex string to be sent as input payload

Added draft test with getting public key and encoding inputs, I think we might need to setup running container of the service to test the integration.

@immortal-tofu @jatZama 