### PR TITLE
feat: throw error if node version out-dated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "fhevmjs",
       "version": "0.5.0-12",
+      "hasInstallScript": true,
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "@types/keccak": "^3.0.4",
@@ -52,6 +53,9 @@
         "webpack": "^5.82.1",
         "webpack-cli": "^5.1.1",
         "webpack-merge": "^5.9.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@adraffy/ens-normalize": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "fhevmjs",
   "version": "0.5.0-12",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "description": "fhEVM SDK for blockchain using TFHE",
   "main": "lib/node.js",
   "types": "lib/node/node.d.ts",
@@ -23,6 +26,7 @@
     }
   },
   "scripts": {
+    "preinstall": "node src/checkNodeVersion.js",
     "lint": "eslint src/",
     "build": "npm run build:lib && npm run build:bundle",
     "build:lib": "rollup -c config/rollup.config.js",

--- a/src/checkNodeVersion.js
+++ b/src/checkNodeVersion.js
@@ -1,0 +1,2 @@
+if (parseFloat(process.versions.node) < 20.0)
+  throw new Error("Unsupported Node.js version. Please use Node.js >= 20.0.0.");


### PR DESCRIPTION
This might be useful to avoid many silently failing tests if Node version is less than 20. Wdyt? 