### PR TITLE
Update node tkms 0.10.0-rc1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
         "fetch-mock": "^11.1.3",
         "keccak": "^3.0.4",
         "node-tfhe": "^0.10.0",
-        "node-tkms": "^0.9.0",
+        "node-tkms": "0.10.0-rc1",
         "tfhe": "^0.9.1",
-        "tkms": "^0.9.0",
+        "tkms": "0.10.0-rc1",
         "wasm-feature-detect": "^1.8.0"
       },
       "bin": {
@@ -6778,10 +6778,9 @@
       "license": "BSD-3-Clause-Clear"
     },
     "node_modules/node-tkms": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-tkms/-/node-tkms-0.9.0.tgz",
-      "integrity": "sha512-ulhV23okeMW3WYnxzhvf9u87tcXqe64JqUFlvdgu64uKteG8re+zwOjzkOdxvF0xSWQbMtEU96dvcrvQM10PEg==",
-      "license": "BSD-3-Clause-Clear"
+      "version": "0.10.0-rc1",
+      "resolved": "https://registry.npmjs.org/node-tkms/-/node-tkms-0.10.0-rc1.tgz",
+      "integrity": "sha512-GcN9Jb/c0YhCy7tmI6OgOk0uRnGylXvOxuT+H3ThNX5fOWbOzFn0Gwn0eZFpuBmTS6EQ/OqTMQ6yBR7BYB6uhQ=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -8165,10 +8164,9 @@
       }
     },
     "node_modules/tkms": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/tkms/-/tkms-0.9.0.tgz",
-      "integrity": "sha512-dSzorTHvIXTYZtn6ACV/iz0GhO/kMRjqGbo3o7JJ3GNbFhsPzbIEtAQ/x+h9nJdwn//VRdsStnOAE0fxUVIGrQ==",
-      "license": "BSD-3-Clause-Clear"
+      "version": "0.10.0-rc1",
+      "resolved": "https://registry.npmjs.org/tkms/-/tkms-0.10.0-rc1.tgz",
+      "integrity": "sha512-42tvVkSCGuNM0W0CxUMj6mv+ArfFvgaqhgnBc7x5nYl1jwxAwCqRO0UVLUICkeSaIqLrvwc53oTD4ZllmIVF7A=="
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -13828,9 +13826,9 @@
       "integrity": "sha512-XDZnj69hideRx4LtYQP8/oiCkB0s0nCqO1l+eBCYSlyqyUCRTHlWMWSDnNIeaDdgNc1j7UjuynFnbtWUjLJSGw=="
     },
     "node-tkms": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-tkms/-/node-tkms-0.9.0.tgz",
-      "integrity": "sha512-ulhV23okeMW3WYnxzhvf9u87tcXqe64JqUFlvdgu64uKteG8re+zwOjzkOdxvF0xSWQbMtEU96dvcrvQM10PEg=="
+      "version": "0.10.0-rc1",
+      "resolved": "https://registry.npmjs.org/node-tkms/-/node-tkms-0.10.0-rc1.tgz",
+      "integrity": "sha512-GcN9Jb/c0YhCy7tmI6OgOk0uRnGylXvOxuT+H3ThNX5fOWbOzFn0Gwn0eZFpuBmTS6EQ/OqTMQ6yBR7BYB6uhQ=="
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -14787,9 +14785,9 @@
       }
     },
     "tkms": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/tkms/-/tkms-0.9.0.tgz",
-      "integrity": "sha512-dSzorTHvIXTYZtn6ACV/iz0GhO/kMRjqGbo3o7JJ3GNbFhsPzbIEtAQ/x+h9nJdwn//VRdsStnOAE0fxUVIGrQ=="
+      "version": "0.10.0-rc1",
+      "resolved": "https://registry.npmjs.org/tkms/-/tkms-0.10.0-rc1.tgz",
+      "integrity": "sha512-42tvVkSCGuNM0W0CxUMj6mv+ArfFvgaqhgnBc7x5nYl1jwxAwCqRO0UVLUICkeSaIqLrvwc53oTD4ZllmIVF7A=="
     },
     "tmpl": {
       "version": "1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fhevmjs",
-  "version": "0.7.0-0",
+  "version": "0.7.0-1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fhevmjs",
-      "version": "0.7.0-0",
+      "version": "0.7.0-1",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "bigint-buffer": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -57,9 +57,9 @@
     "fetch-mock": "^11.1.3",
     "keccak": "^3.0.4",
     "node-tfhe": "^0.10.0",
-    "node-tkms": "^0.9.0",
+    "node-tkms": "0.10.0-rc1",
     "tfhe": "^0.9.1",
-    "tkms": "^0.9.0",
+    "tkms": "0.10.0-rc1",
     "wasm-feature-detect": "^1.8.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fhevmjs",
-  "version": "0.7.0-0",
+  "version": "0.7.0-1",
   "description": "fhEVM SDK for blockchain using TFHE",
   "main": "lib/node.js",
   "types": "lib/node/node.d.ts",


### PR DESCRIPTION
tkms-0.10 is needed to support kms v0.10 (which is not compatible with kms v0.9 due to the tfhe-rs upgrade and reencryption changes)