### PR TITLE
refactor: migrate to pure ESM dependencies for better Vite compatibility

### DIFF
--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -77,7 +77,7 @@ export default [
     plugins: [...nodePlugins],
     // Suppress warning
     // https://rollupjs.org/troubleshooting/#warning-treating-module-as-external-dependency
-    external: ['ethers', 'fetch-retry', 'node-tfhe', 'node-tkms', 'keccak'],
+    external: ['ethers', 'ky', 'node-tfhe', 'node-tkms', 'keccak'],
   },
   {
     input: 'src/node.ts',
@@ -89,6 +89,6 @@ export default [
     plugins: [...nodePlugins],
     // Suppress warning
     // https://rollupjs.org/troubleshooting/#warning-treating-module-as-external-dependency
-    external: ['ethers', 'fetch-retry', 'node-tfhe', 'node-tkms', 'keccak'],
+    external: ['ethers', 'ky', 'node-tfhe', 'node-tkms', 'keccak'],
   },
 ];

--- a/package.json
+++ b/package.json
@@ -56,8 +56,7 @@
   "dependencies": {
     "commander": "^14.0.0",
     "ethers": "^6.15.0",
-    "fetch-retry": "^6.0.0",
-    "keccak": "^3.0.4",
+    "ky": "^1.12.0",
     "node-tfhe": "1.3.0",
     "node-tkms": "^0.11.0",
     "tfhe": "1.3.0",
@@ -79,7 +78,6 @@
     "@rollup/plugin-wasm": "6.2.2",
     "@surma/rollup-plugin-off-main-thread": "2.2.3",
     "@types/jest": "30.0.0",
-    "@types/keccak": "3.0.5",
     "@types/node-fetch": "2.6.12",
     "buffer": "6.0.3",
     "crypto-browserify": "3.12.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,9 +27,16 @@ import { DecryptedResults } from './relayer/decryptUtils';
 import { PublicParams } from './sdk/encrypt';
 import { generateKeypair, createEIP712, EIP712 } from './sdk/keypair';
 
-import fetchRetry from 'fetch-retry';
+import ky from 'ky';
 
-global.fetch = fetchRetry(global.fetch, { retries: 5, retryDelay: 500 });
+// Create a dedicated fetch instance with retry logic for relayer network requests
+// Note: We don't wrap global.fetch to avoid interfering with WASM module loading
+export const retryFetch = ky.create({
+  retry: {
+    limit: 5,
+    delay: () => 500, // Fixed 500ms delay
+  },
+});
 
 export {
   generateKeypair,

--- a/src/relayer/fetchRelayer.ts
+++ b/src/relayer/fetchRelayer.ts
@@ -1,4 +1,5 @@
 import { Auth, setAuth } from '../auth';
+import { retryFetch } from '../index';
 import {
   throwRelayerUnexpectedJSONError,
   throwRelayerJSONError,
@@ -145,7 +146,7 @@ export async function fetchRelayerJsonRpcPost(
   let response: Response;
   let json: RelayerFetchResponseJson;
   try {
-    response = await fetch(url, init);
+    response = await retryFetch(url, init);
   } catch (e) {
     throwRelayerUnknownError(relayerOperation, e);
   }
@@ -177,7 +178,7 @@ export async function fetchRelayerGet(
   let response: Response;
   let json: RelayerFetchResponseJson;
   try {
-    response = await fetch(url);
+    response = await retryFetch(url);
   } catch (e) {
     throwRelayerUnknownError(relayerOperation, e);
   }

--- a/src/relayer/network.ts
+++ b/src/relayer/network.ts
@@ -1,4 +1,5 @@
 import { SERIALIZED_SIZE_LIMIT_PK, SERIALIZED_SIZE_LIMIT_CRS } from '../utils';
+import { retryFetch } from '../index';
 import { fetchRelayerGet, RelayerKeyUrlResponse } from './fetchRelayer';
 
 // export type RelayerKeysItem = {
@@ -79,7 +80,7 @@ export const getKeysFromRelayer = async (
       pubKeyUrl = keyInfo.fhe_public_key.urls[0];
     }
 
-    const publicKeyResponse = await fetch(pubKeyUrl);
+    const publicKeyResponse = await retryFetch(pubKeyUrl);
     if (!publicKeyResponse.ok) {
       throw new Error(
         `HTTP error! status: ${publicKeyResponse.status} on ${publicKeyResponse.url}`,
@@ -97,7 +98,7 @@ export const getKeysFromRelayer = async (
     const publicParamsUrl = data.response.crs['2048'].urls[0];
     const publicParamsId = data.response.crs['2048'].data_id;
 
-    const publicParams2048Response = await fetch(publicParamsUrl);
+    const publicParams2048Response = await retryFetch(publicParamsUrl);
     if (!publicParams2048Response.ok) {
       throw new Error(
         `HTTP error! status: ${publicParams2048Response.status} on ${publicParams2048Response.url}`,


### PR DESCRIPTION
## Summary

Migrate from CommonJS dependencies (fetch-retry, keccak) to pure ESM alternatives (ky, ethers built-in crypto) to improve compatibility with modern bundlers like Vite.

## Problem

When using `@zama-fhe/relayer-sdk` in Vite projects, the package must be excluded from pre-bundling (`optimizeDeps.exclude`) because it contains CASM files. However, this causes Vite to fail when processing CommonJS dependencies within the excluded package.

## Solution

- Replace `fetch-retry` with `ky` (pure ESM HTTP client with retry support)
- Replace `keccak` package with ethers' built-in `keccak256`, `concat`, and `getBytes` functions

## Benefits

- ✅ Better Vite compatibility
- ✅ Eliminates CommonJS dependencies for improved tree-shaking
- ✅ Reduces package count (removes `keccak`, `@types/keccak`, `fetch-retry`)

