### PR TITLE
test: added unit tests for abiEncodeClearValues bool and address types

### DIFF
--- a/src/relayer/publicDecrypt.ts
+++ b/src/relayer/publicDecrypt.ts
@@ -44,7 +44,7 @@ function isThresholdReached(
   return recoveredAddresses.length >= threshold;
 }
 
-function abiEncodeClearValues(clearValues: ClearValues) {
+export function abiEncodeClearValues(clearValues: ClearValues) {
   const handlesBytes32Hex = Object.keys(clearValues) as `0x${string}`[];
 
   const abiTypes: string[] = [];


### PR DESCRIPTION
Added missing unit tests for `abiEncodeClearValues` covering `ebool` and `eaddress` types.

- Tests ebool encoding with true/false/BigInt values
- Tests eaddress encoding with valid/zero addresses
- Tests error handling for invalid ebool values

---

Closes #353 