### PR TITLE
docs: update sdk docs for user and public decryption

### DIFF
--- a/docs/public-decryption.md
+++ b/docs/public-decryption.md
@@ -8,6 +8,10 @@ Public decryption can be done using the Relayer HTTP endpoint.
 
 Calling the public decryption endpoint of the Relayer can be done easily using the following code snippet.
 
+{% hint style="info" %}
+The total bit length of all ciphertexts being decrypted in a single request must not exceed 2048 bits. Each encrypted type has a specific bit length, for instance `euint8` uses 8 bits and `euint16` uses 16 bits. For the full list of encrypted types and their corresponding bit lengths, refer to the [encrypted types documentation](https://docs.zama.org/protocol/solidity-guides/smart-contract/types#list-of-encrypted-types).
+{% endhint %}
+
 ```ts
 // A list of ciphertexts handles to decrypt
 const handles = [

--- a/docs/user-decryption.md
+++ b/docs/user-decryption.md
@@ -48,8 +48,13 @@ For more details on the topic please refer to [the ACL documentation](https://do
 
 ## Step 2: decrypt the ciphertext
 
-Using that ciphertext handle user decryption is performed client-side using the `@zama-fhe/relayer-sdk` library.
+Using those ciphertext handles, user decryption is performed client-side using the `@zama-fhe/relayer-sdk` library.
+The `userDecrypt` function takes a **list of handles**, allowing you to decrypt multiple ciphertexts in a single request. In this example, provide just one handle.
 The user needs to have created an instance object prior to that (for more context see [the relayer-sdk setup page](./initialization.md)).
+
+{% hint style="info" %}
+The total bit length of all ciphertexts being decrypted in a single request must not exceed 2048 bits. Each encrypted type has a specific bit length, for instance `euint8` uses 8 bits and `euint16` uses 16 bits. For the full list of encrypted types and their corresponding bit lengths, refer to the [encrypted types documentation](https://docs.zama.org/protocol/solidity-guides/smart-contract/types#list-of-encrypted-types).
+{% endhint %}
 
 ```ts
 // instance: [`FhevmInstance`] from `zama-fhe/relayer-sdk`
@@ -58,6 +63,8 @@ The user needs to have created an instance object prior to that (for more contex
 // contractAddress: [`string`]
 
 const keypair = instance.generateKeypair();
+// userDecrypt can take a batch of handles (with their corresponding contract addresses).
+// In this example we only pass one handle.
 const handleContractPairs = [
   {
     handle: ciphertextHandle,
@@ -94,5 +101,6 @@ const result = await instance.userDecrypt(
   durationDays,
 );
 
+// result maps each handle to its decrypted value
 const decryptedValue = result[ciphertextHandle];
 ```


### PR DESCRIPTION
- In both cases, add an info banner that the total bit length of ciphertexts being decrypted should not exceed 2048 bits.

- In user decrypt, emphasize that API supports batch decryption.