### PR TITLE
ci: add write permissions to security-events for zizmor

### DIFF
--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -11,7 +11,7 @@ jobs:
   publish:
     name: test-npm-publish/publish
     permissions:
-      security-events: 'write'
+      security-events: 'write' # Required for zizmor to upload its results.
       id-token: 'write'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Fixes the test-publish workflow failing due to Zizmor Action, which missed write permissions to `security-events` when using GitHub Advanced Security.