### PR TITLE
fix: improve error messages for public key fetch failures

### DIFF
--- a/src/relayer-provider/v2/RelayerV2PublicKey.ts
+++ b/src/relayer-provider/v2/RelayerV2PublicKey.ts
@@ -87,7 +87,7 @@ export class RelayerV2PublicKey {
 
       return new RelayerV2PublicKey({ publicKey, crs2048: crs });
     } catch (e) {
-      throw new Error('Impossible to fetch public key: wrong relayer url.', {
+      throw new Error('Failed to initialize public key from relayer response', {
         cause: e,
       });
     }

--- a/src/relayer-provider/v2/TFHECrs.ts
+++ b/src/relayer-provider/v2/TFHECrs.ts
@@ -318,7 +318,7 @@ export class TFHECrs {
       return TFHECrs._fromUrl(params);
     } catch (e) {
       throw new TFHECrsError({
-        message: 'Impossible to fetch public key: wrong relayer url.',
+        message: 'Failed to fetch or deserialize CRS from URL',
         cause: e,
       });
     }

--- a/src/relayer-provider/v2/TFHEPublicKey.ts
+++ b/src/relayer-provider/v2/TFHEPublicKey.ts
@@ -193,7 +193,8 @@ export class TFHEPublicKey {
       TFHEPublicKey.assertKeyUrlType(params, 'arg');
       return TFHEPublicKey._fromUrl(params);
     } catch (e) {
-      throw new Error('Impossible to fetch public key: wrong relayer url.', {
+      throw new TFHEPublicKeyError({
+        message: 'Failed to fetch or deserialize public key from URL',
         cause: e,
       });
     }

--- a/src/relayer/network.ts
+++ b/src/relayer/network.ts
@@ -116,7 +116,7 @@ export const getKeysFromRelayer = async (
     keyurlCache[versionUrl] = result;
     return result;
   } catch (e) {
-    throw new Error('Impossible to fetch public key: wrong relayer url.', {
+    throw new Error('Failed to fetch or deserialize public key', {
       cause: e,
     });
   }


### PR DESCRIPTION
- Replace misleading 'Impossible to fetch public key: wrong relayer url.' message

- Use context-specific messages for different error scenarios

- network.ts: 'Failed to fetch or deserialize public key'

- RelayerV2PublicKey.ts: 'Failed to initialize public key from relayer response'

- TFHECrs.ts: 'Failed to fetch or deserialize CRS from URL'

- TFHEPublicKey.ts: 'Failed to fetch or deserialize public key from URL'

- Use TFHEPublicKeyError instead of generic Error in TFHEPublicKey.ts

- Preserve original error in cause for debugging