### PR TITLE
chore: fix jest + ethers tests

### DIFF
--- a/src/relayer-provider/v1/RelayerV1Fhevm.test.ts
+++ b/src/relayer-provider/v1/RelayerV1Fhevm.test.ts
@@ -1,10 +1,8 @@
-import { SepoliaConfig } from '../../configs';
 import { createRelayerFhevm } from '../createRelayerFhevm';
 import fetchMock from 'fetch-mock';
 import { tfheCompactPkeCrsBytes, tfheCompactPublicKeyBytes } from '../../test';
 import { RelayerV1Fhevm } from './RelayerV1Fhevm';
-import { TEST_CONFIG } from '../../test/config';
-import { setupV1RoutesKeyUrl } from '../../test/v1/mockRoutes';
+import { setupAllFetchMockRoutes, TEST_CONFIG } from '../../test/config';
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -16,34 +14,37 @@ import { setupV1RoutesKeyUrl } from '../../test/v1/mockRoutes';
 // npx jest --colors --passWithNoTests --coverage ./src/relayer-provider/v1/RelayerV1Fhevm.test.ts --collectCoverageFrom=./src/relayer-provider/v1/RelayerV1Fhevm.ts --testNamePattern=xxx
 // npx jest --colors --passWithNoTests --coverage ./src/relayer-provider/v1/RelayerV1Fhevm.test.ts --collectCoverageFrom=./src/relayer-provider/v1/RelayerV1Fhevm.ts
 //
+// Testnet:
+// ========
 //
-// Curl Testnet:
-// =============
-//
-// curl https://relayer.testnet.zama.org/v1/keyurl
+// npx jest --config jest.testnet.config.cjs --colors --passWithNoTests ./src/relayer-provider/v1/RelayerV1Fhevm.test.ts
 //
 ////////////////////////////////////////////////////////////////////////////////
-
-const defaultRelayerVersion = 1;
-const relayerUrlV1 = `${SepoliaConfig.relayerUrl!}/v1`;
 
 const describeIfFetchMock =
   TEST_CONFIG.type === 'fetch-mock' ? describe : describe.skip;
 
+jest.mock('ethers', () => {
+  const { setupEthersJestMock } = jest.requireActual('../../test/config');
+  return setupEthersJestMock();
+});
+
+////////////////////////////////////////////////////////////////////////////////
+// Mock only, compares with keys assets
 ////////////////////////////////////////////////////////////////////////////////
 
 describeIfFetchMock('RelayerV1Fhevm', () => {
   beforeEach(async () => {
     fetchMock.removeRoutes();
-    setupV1RoutesKeyUrl();
+    setupAllFetchMockRoutes();
   });
 
   //////////////////////////////////////////////////////////////////////////////
 
   it('v1: createRelayerFhevm', async () => {
     const relayerFhevm = await createRelayerFhevm({
-      ...SepoliaConfig,
-      defaultRelayerVersion,
+      ...TEST_CONFIG.v1.fhevmInstanceConfig,
+      defaultRelayerVersion: 1,
     });
     expect(relayerFhevm.version).toBe(1);
   });
@@ -52,8 +53,8 @@ describeIfFetchMock('RelayerV1Fhevm', () => {
 
   it('v1: getPublicKey().publicKeyId', async () => {
     const relayerFhevm = await createRelayerFhevm({
-      ...SepoliaConfig,
-      defaultRelayerVersion,
+      ...TEST_CONFIG.v1.fhevmInstanceConfig,
+      defaultRelayerVersion: 1,
     });
     const pub_key = relayerFhevm.getPublicKeyBytes();
     expect(pub_key.id).toBe('fhe-public-key-data-id');
@@ -63,8 +64,8 @@ describeIfFetchMock('RelayerV1Fhevm', () => {
 
   it('v1: getPublicKey().publicKey', async () => {
     const relayerFhevm = await createRelayerFhevm({
-      ...SepoliaConfig,
-      defaultRelayerVersion,
+      ...TEST_CONFIG.v1.fhevmInstanceConfig,
+      defaultRelayerVersion: 1,
     });
     const pub_key = relayerFhevm.getPublicKeyBytes();
     expect(pub_key.bytes).toStrictEqual(tfheCompactPublicKeyBytes);
@@ -74,8 +75,8 @@ describeIfFetchMock('RelayerV1Fhevm', () => {
 
   it('v1: getPublicParams(2048).publicParamsId', async () => {
     const relayerFhevm = await createRelayerFhevm({
-      ...SepoliaConfig,
-      defaultRelayerVersion,
+      ...TEST_CONFIG.v1.fhevmInstanceConfig,
+      defaultRelayerVersion: 1,
     });
     const pub_params = relayerFhevm.getPkeCrsBytesForCapacity(2048);
     expect(pub_params.id).toBe('crs-data-id');
@@ -85,8 +86,8 @@ describeIfFetchMock('RelayerV1Fhevm', () => {
 
   it('v1: getPublicParams(2048).publicParams', async () => {
     const relayerFhevm = await createRelayerFhevm({
-      ...SepoliaConfig,
-      defaultRelayerVersion,
+      ...TEST_CONFIG.v1.fhevmInstanceConfig,
+      defaultRelayerVersion: 1,
     });
     const pub_params = relayerFhevm.getPkeCrsBytesForCapacity(2048);
     expect(pub_params.bytes).toStrictEqual(tfheCompactPkeCrsBytes);
@@ -96,8 +97,8 @@ describeIfFetchMock('RelayerV1Fhevm', () => {
 
   it('v1: getPublicParams(123).publicParams', async () => {
     const relayerFhevm = await createRelayerFhevm({
-      ...SepoliaConfig,
-      defaultRelayerVersion,
+      ...TEST_CONFIG.v1.fhevmInstanceConfig,
+      defaultRelayerVersion: 1,
     });
     expect(() => relayerFhevm.getPkeCrsBytesForCapacity(123)).toThrow(
       "Unsupported PublicParams bits format '123'",
@@ -108,12 +109,14 @@ describeIfFetchMock('RelayerV1Fhevm', () => {
 
   it('v1: relayerProvider()', async () => {
     const relayerFhevm = await createRelayerFhevm({
-      ...SepoliaConfig,
-      defaultRelayerVersion,
+      ...TEST_CONFIG.v1.fhevmInstanceConfig,
+      defaultRelayerVersion: 1,
     });
     expect(relayerFhevm instanceof RelayerV1Fhevm).toBe(true);
     const relayerFhevmV1 = relayerFhevm as RelayerV1Fhevm;
-    expect(relayerFhevmV1.relayerProvider.url).toEqual(relayerUrlV1);
+    expect(relayerFhevmV1.relayerProvider.url).toEqual(
+      TEST_CONFIG.v1.fhevmInstanceConfig.relayerUrl,
+    );
     expect(relayerFhevmV1.relayerProvider.version).toEqual(1);
   });
 
@@ -121,15 +124,15 @@ describeIfFetchMock('RelayerV1Fhevm', () => {
 
   it('v1: createRelayerFhevm from publicKey and publicParams', async () => {
     const relayerFhevm1 = await createRelayerFhevm({
-      ...SepoliaConfig,
-      defaultRelayerVersion,
+      ...TEST_CONFIG.v1.fhevmInstanceConfig,
+      defaultRelayerVersion: 1,
     });
     const pub_key = relayerFhevm1.getPublicKeyBytes();
     const pub_params = relayerFhevm1.getPkeCrsBytesForCapacity(2048);
 
     const relayerFhevm2 = await createRelayerFhevm({
-      ...SepoliaConfig,
-      defaultRelayerVersion,
+      ...TEST_CONFIG.v1.fhevmInstanceConfig,
+      defaultRelayerVersion: 1,
       publicKey: {
         data: pub_key.bytes,
         id: pub_key.id,

--- a/src/relayer-provider/v2/RelayerV2Fhevm.test.ts
+++ b/src/relayer-provider/v2/RelayerV2Fhevm.test.ts
@@ -1,4 +1,3 @@
-import { SepoliaConfig } from '../../configs';
 import { createRelayerFhevm } from '../createRelayerFhevm';
 import fetchMock from 'fetch-mock';
 import { RelayerV2Fhevm } from './RelayerV2Fhevm';
@@ -16,12 +15,22 @@ import { setupV2RoutesKeyUrl } from '../../test/v2/mockRoutes';
 // npx jest --colors --passWithNoTests ./src/relayer-provider/v2/RelayerV2Fhevm.test.ts --testNamePattern=xxx
 // npx jest --colors --passWithNoTests --coverage ./src/relayer-provider/v2/RelayerV2Fhevm.test.ts --collectCoverageFrom=./src/relayer-provider/v2/RelayerV2Fhevm.ts
 //
+// Testnet:
+// ========
+//
+// npx jest --config jest.testnet.config.cjs --colors --passWithNoTests ./src/relayer-provider/v1/RelayerV1Fhevm.test.ts
+//
 ////////////////////////////////////////////////////////////////////////////////
-
-const relayerUrlV2 = `${SepoliaConfig.relayerUrl!}/v2`;
 
 const describeIfFetchMock =
   TEST_CONFIG.type === 'fetch-mock' ? describe : describe.skip;
+
+jest.mock('ethers', () => {
+  const { setupEthersJestMock } = jest.requireActual('../../test/config');
+  return setupEthersJestMock();
+});
+
+////////////////////////////////////////////////////////////////////////////////
 
 describeIfFetchMock('RelayerV2Fhevm', () => {
   beforeEach(async () => {
@@ -32,11 +41,9 @@ describeIfFetchMock('RelayerV2Fhevm', () => {
   //////////////////////////////////////////////////////////////////////////////
 
   it('v2: createRelayerFhevm', async () => {
-    const SepoliaConfigRelayerUrl = SepoliaConfig.relayerUrl!;
     const relayerFhevm = await createRelayerFhevm({
-      ...SepoliaConfig,
-      relayerUrl: `${SepoliaConfigRelayerUrl}/v2`,
-      defaultRelayerVersion: 1,
+      ...TEST_CONFIG.v2.fhevmInstanceConfig,
+      defaultRelayerVersion: 2,
     });
     expect(relayerFhevm.version).toBe(2);
   });
@@ -44,11 +51,9 @@ describeIfFetchMock('RelayerV2Fhevm', () => {
   //////////////////////////////////////////////////////////////////////////////
 
   it('v2: getPublicKey().publicKeyId', async () => {
-    const SepoliaConfigRelayerUrl = SepoliaConfig.relayerUrl!;
     const relayerFhevm = await createRelayerFhevm({
-      ...SepoliaConfig,
-      relayerUrl: `${SepoliaConfigRelayerUrl}/v2`,
-      defaultRelayerVersion: 1,
+      ...TEST_CONFIG.v2.fhevmInstanceConfig,
+      defaultRelayerVersion: 2,
     });
     const pub_key = relayerFhevm.getPublicKeyBytes();
     expect(pub_key.id).toBe('fhe-public-key-data-id');
@@ -58,9 +63,8 @@ describeIfFetchMock('RelayerV2Fhevm', () => {
 
   it('v2: getPublicKey().publicKey', async () => {
     const relayerFhevm = await createRelayerFhevm({
-      ...SepoliaConfig,
-      relayerUrl: `${SepoliaConfig.relayerUrl!}/v2`,
-      defaultRelayerVersion: 1,
+      ...TEST_CONFIG.v2.fhevmInstanceConfig,
+      defaultRelayerVersion: 2,
     });
     const pub_key = relayerFhevm.getPublicKeyBytes();
     expect(pub_key.bytes).toStrictEqual(tfheCompactPublicKeyBytes);
@@ -70,9 +74,8 @@ describeIfFetchMock('RelayerV2Fhevm', () => {
 
   it('v2: getPublicParams().publicParamsId', async () => {
     const relayerFhevm = await createRelayerFhevm({
-      ...SepoliaConfig,
-      relayerUrl: `${SepoliaConfig.relayerUrl!}/v2`,
-      defaultRelayerVersion: 1,
+      ...TEST_CONFIG.v2.fhevmInstanceConfig,
+      defaultRelayerVersion: 2,
     });
     const pub_params = relayerFhevm.getPkeCrsBytesForCapacity(2048);
     expect(pub_params.id).toBe('crs-data-id');
@@ -82,9 +85,8 @@ describeIfFetchMock('RelayerV2Fhevm', () => {
 
   it('v2: getPublicParams().publicParams', async () => {
     const relayerFhevm = await createRelayerFhevm({
-      ...SepoliaConfig,
-      relayerUrl: `${SepoliaConfig.relayerUrl!}/v2`,
-      defaultRelayerVersion: 1,
+      ...TEST_CONFIG.v2.fhevmInstanceConfig,
+      defaultRelayerVersion: 2,
     });
     const pub_params = relayerFhevm.getPkeCrsBytesForCapacity(2048);
     expect(pub_params.bytes).toStrictEqual(tfheCompactPkeCrsBytes);
@@ -94,9 +96,8 @@ describeIfFetchMock('RelayerV2Fhevm', () => {
 
   it('v2: getPublicParams(123).publicParams', async () => {
     const relayerFhevm = await createRelayerFhevm({
-      ...SepoliaConfig,
-      relayerUrl: `${SepoliaConfig.relayerUrl!}/v2`,
-      defaultRelayerVersion: 1,
+      ...TEST_CONFIG.v2.fhevmInstanceConfig,
+      defaultRelayerVersion: 2,
     });
     expect(() => relayerFhevm.getPkeCrsBytesForCapacity(123)).toThrow(
       new TFHEError({
@@ -109,13 +110,14 @@ describeIfFetchMock('RelayerV2Fhevm', () => {
 
   it('v2: relayerProvider()', async () => {
     const relayerFhevm = await createRelayerFhevm({
-      ...SepoliaConfig,
-      relayerUrl: `${SepoliaConfig.relayerUrl!}/v2`,
-      defaultRelayerVersion: 1,
+      ...TEST_CONFIG.v2.fhevmInstanceConfig,
+      defaultRelayerVersion: 2,
     });
     expect(relayerFhevm instanceof RelayerV2Fhevm).toBe(true);
     const relayerFhevmV2 = relayerFhevm as RelayerV2Fhevm;
-    expect(relayerFhevmV2.relayerProvider.url).toEqual(relayerUrlV2);
+    expect(relayerFhevmV2.relayerProvider.url).toEqual(
+      TEST_CONFIG.v2.fhevmInstanceConfig.relayerUrl,
+    );
     expect(relayerFhevmV2.relayerProvider.version).toEqual(2);
   });
 
@@ -123,16 +125,14 @@ describeIfFetchMock('RelayerV2Fhevm', () => {
 
   it('v2: createRelayerFhevm from publicKey and publicParams', async () => {
     const relayerFhevm1 = await createRelayerFhevm({
-      ...SepoliaConfig,
-      relayerUrl: `${SepoliaConfig.relayerUrl!}/v2`,
-      defaultRelayerVersion: 1,
+      ...TEST_CONFIG.v2.fhevmInstanceConfig,
+      defaultRelayerVersion: 2,
     });
     const pub_key = relayerFhevm1.getPublicKeyBytes();
     const pub_params = relayerFhevm1.getPkeCrsBytesForCapacity(2048);
 
     const relayerFhevm2 = await createRelayerFhevm({
-      ...SepoliaConfig,
-      relayerUrl: `${SepoliaConfig.relayerUrl!}/v2`,
+      ...TEST_CONFIG.v2.fhevmInstanceConfig,
       publicKey: {
         data: pub_key.bytes,
         id: pub_key.id,
@@ -143,7 +143,7 @@ describeIfFetchMock('RelayerV2Fhevm', () => {
           publicParamsId: pub_params.id,
         },
       },
-      defaultRelayerVersion: 1,
+      defaultRelayerVersion: 2,
     });
 
     expect(relayerFhevm2.getPublicKeyBytes()).toStrictEqual(

--- a/src/relayer-provider/v2/RelayerV2Provider_user-decrypt.test.ts
+++ b/src/relayer-provider/v2/RelayerV2Provider_user-decrypt.test.ts
@@ -26,6 +26,8 @@ import type {
 import type { RelayerUserDecryptPayload } from '../types/public-api';
 import type { FhevmInstanceConfig } from '../../types/relayer';
 
+////////////////////////////////////////////////////////////////////////////////
+//
 // Jest Command line
 // =================
 // npx jest --colors --passWithNoTests ./src/relayer-provider/v2/RelayerV2Provider_user-decrypt.test.ts --testNamePattern=xxx
@@ -40,6 +42,13 @@ import type { FhevmInstanceConfig } from '../../types/relayer';
 // Testnet:
 // =======
 // npx jest --config jest.testnet.config.cjs --colors --passWithNoTests ./src/relayer-provider/v2/RelayerV2Provider_user-decrypt.test.ts
+//
+////////////////////////////////////////////////////////////////////////////////
+
+jest.mock('ethers', () => {
+  const { setupEthersJestMock } = jest.requireActual('../../test/config');
+  return setupEthersJestMock();
+});
 
 const payload: RelayerUserDecryptPayload = {
   handleContractPairs: [
@@ -532,7 +541,7 @@ describe('FhevmInstance.createEIP712', () => {
     expect(recoveredAddresses[0]).toBe(userSigner.address);
   }
 
-  it('xxx v1: createEIP712 succeeded', async () => {
+  it('v1: createEIP712 succeeded', async () => {
     setupAllFetchMockRoutes({
       enableInputProofRoutes: false,
     });


### PR DESCRIPTION
- fix edge case in jest tests using fetch mock + ethers. At init some ethers functions were trying to access the web bypassing fetch mock routes.