### PR TITLE
fix: enforce runtime constructor guard on KMSVerifier and InputVerifier

### DIFF
--- a/src/sdk/InputVerifier.ts
+++ b/src/sdk/InputVerifier.ts
@@ -15,6 +15,10 @@ export class InputVerifier {
     'function eip712Domain() view returns (bytes1 fields, string name, string version, uint256 chainId, address verifyingContract, bytes32 salt, uint256[] extensions)',
   ] as const;
 
+  static readonly #constructorGuard: unique symbol = Symbol(
+    'InputVerifier.constructorGuard',
+  );
+
   static {
     Object.freeze(InputVerifier.#abi);
   }
@@ -24,12 +28,20 @@ export class InputVerifier {
   readonly #coprocessorSigners: ChecksummedAddress[];
   readonly #coprocessorSignerThreshold: number;
 
-  private constructor(params: {
-    address: ChecksummedAddress;
-    eip712Domain: CoprocessorEIP712DomainType;
-    coprocessorSigners: ChecksummedAddress[];
-    coprocessorSignerThreshold: number;
-  }) {
+  private constructor(
+    guard: symbol,
+    params: {
+      address: ChecksummedAddress;
+      eip712Domain: CoprocessorEIP712DomainType;
+      coprocessorSigners: ChecksummedAddress[];
+      coprocessorSignerThreshold: number;
+    },
+  ) {
+    if (guard !== InputVerifier.#constructorGuard) {
+      throw new Error(
+        'InputVerifier cannot be constructed directly. Use InputVerifier.loadFromChain() or createInstance() instead.',
+      );
+    }
     this.#address = params.address;
     this.#eip712Domain = { ...params.eip712Domain };
     this.#coprocessorSigners = [...params.coprocessorSigners];
@@ -144,7 +156,7 @@ export class InputVerifier {
       );
     }
 
-    const inputVerifier = new InputVerifier({
+    const inputVerifier = new InputVerifier(InputVerifier.#constructorGuard, {
       address: params.inputVerifierContractAddress,
       eip712Domain: eip712Domain,
       coprocessorSignerThreshold: Number(threshold),

--- a/src/sdk/KMSVerifier.ts
+++ b/src/sdk/KMSVerifier.ts
@@ -15,6 +15,10 @@ export class KMSVerifier {
     'function eip712Domain() view returns (bytes1 fields, string name, string version, uint256 chainId, address verifyingContract, bytes32 salt, uint256[] extensions)',
   ] as const;
 
+  static readonly #constructorGuard: unique symbol = Symbol(
+    'KMSVerifier.constructorGuard',
+  );
+
   static {
     Object.freeze(KMSVerifier.#abi);
   }
@@ -25,12 +29,20 @@ export class KMSVerifier {
   readonly #kmsSigners: ChecksummedAddress[];
   readonly #kmsSignerThreshold: number;
 
-  private constructor(params: {
-    address: ChecksummedAddress;
-    eip712Domain: KmsEIP712DomainType;
-    kmsSigners: ChecksummedAddress[];
-    kmsSignerThreshold: number;
-  }) {
+  private constructor(
+    guard: symbol,
+    params: {
+      address: ChecksummedAddress;
+      eip712Domain: KmsEIP712DomainType;
+      kmsSigners: ChecksummedAddress[];
+      kmsSignerThreshold: number;
+    },
+  ) {
+    if (guard !== KMSVerifier.#constructorGuard) {
+      throw new Error(
+        'KMSVerifier cannot be constructed directly. Use KMSVerifier.loadFromChain() or createInstance() instead.',
+      );
+    }
     this.#address = params.address;
     this.#verifyingContractAddressDecryption =
       params.eip712Domain.verifyingContract;
@@ -139,7 +151,7 @@ export class KMSVerifier {
       );
     }
 
-    const kmsVerifier = new KMSVerifier({
+    const kmsVerifier = new KMSVerifier(KMSVerifier.#constructorGuard, {
       address: params.kmsContractAddress,
       eip712Domain: eip712Domain,
       kmsSignerThreshold: Number(kmsSignerThreshold),


### PR DESCRIPTION
## Summary

Closes #435

- Adds a runtime Symbol guard to `KMSVerifier` and `InputVerifier` constructors, enforcing that instances can only be created through `loadFromChain()` (and by extension `createInstance()`)
- TypeScript's `private constructor` is compile-time only — in the bundled JS, consumers like `@zama-fhe/sdk` can call `new KMSVerifier({...})` directly, bypassing all `loadFromChain()` validation
- When `verifyingContract` is null (e.g. from a broken RPC response in a `worker_threads` context), the unvalidated value propagates through the closure chain to the WASM layer, which crashes with a cryptic `"addressnull"` error
- The static private `#constructorGuard` Symbol is inaccessible outside the class even at JS runtime, so direct construction now throws with an actionable message

## Test plan

- [x] `tsc --noEmit` passes
- [x] All 49 KMSVerifier + InputVerifier unit tests pass
- [x] Full test suite passes (1327 tests, 68 suites)
- [ ] Verify `new KMSVerifier({...})` throws at runtime in a consumer context (e.g. `@zama-fhe/sdk` worker)
- [ ] Verify `createInstance()` still works end-to-end in `worker_threads`

🤖 Generated with [Claude Code](https://claude.com/claude-code)