### PR TITLE
chore: bump tkms to v0.13.20-0, tfhe to v1.6.1 and set version to v0.5.0-rc.2

### DIFF
--- a/docs/initialization.md
+++ b/docs/initialization.md
@@ -71,11 +71,6 @@ const instance = await createInstance({
 });
 ```
 
-<!-- commented out, since the doc page does not exist (anymore?)
-{% hint style="info" %}
-For more information on the Relayer's part, please refer to [the Relayer SDK documentation](https://docs.zama.org/protocol/relayer-sdk-guides).
-{% endhint %} -->
-
 # Network Configuration
 
 The `network` property in `FhevmInstanceConfig` is required and specifies how the SDK connects to the FHEVM host chain. It accepts two types of values:

--- a/docs/initialization.md
+++ b/docs/initialization.md
@@ -71,9 +71,10 @@ const instance = await createInstance({
 });
 ```
 
+<!-- commented out, since the doc page does not exist (anymore?)
 {% hint style="info" %}
 For more information on the Relayer's part, please refer to [the Relayer SDK documentation](https://docs.zama.org/protocol/relayer-sdk-guides).
-{% endhint %}
+{% endhint %} -->
 
 # Network Configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
   "name": "@zama-fhe/relayer-sdk",
-  "version": "0.5.0-alpha.3",
+  "version": "0.5.0-alpha.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zama-fhe/relayer-sdk",
-      "version": "0.5.0-alpha.3",
+      "version": "0.5.0-alpha.4",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "commander": "^14.0.0",
         "ethers": "^6.15.0",
         "fetch-retry": "^6.0.0",
         "keccak": "^3.0.4",
-        "node-tfhe": "1.5.4",
-        "node-tkms": "0.13.10",
-        "tfhe": "1.5.4",
-        "tkms": "0.13.10",
+        "node-tfhe": "1.6.1",
+        "node-tkms": "0.13.20-0",
+        "tfhe": "1.6.1",
+        "tkms": "0.13.20-0",
         "wasm-feature-detect": "^1.8.0"
       },
       "bin": {
@@ -9439,15 +9439,15 @@
       }
     },
     "node_modules/node-tfhe": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/node-tfhe/-/node-tfhe-1.5.4.tgz",
-      "integrity": "sha512-azTefAcK7G/uLP+uDFN8v5XBPFlY8Cu8NZ5ZMw4rgvWB6DNbtOcoUhDoJKrhPvOD2jt1HrzQQsLfao6kNHQybA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/node-tfhe/-/node-tfhe-1.6.1.tgz",
+      "integrity": "sha512-gWdtZwEh6FR5C79NaJviY7Q38TNL1tU3S+sTLWKoAeyTKa/9Nn7/VCNTAsrCaYKtefEfvzfMkjKVgjZl2q3vnw==",
       "license": "BSD-3-Clause-Clear"
     },
     "node_modules/node-tkms": {
-      "version": "0.13.10",
-      "resolved": "https://registry.npmjs.org/node-tkms/-/node-tkms-0.13.10.tgz",
-      "integrity": "sha512-6F3Q2qfGcNQ2ffx2b+iT3+v3Nqh7CL7TkFNP1LuuGucfIMbZpQ8Eat4pFyZ90p4zVSj66D5xvhM0btnic3zbog==",
+      "version": "0.13.20-0",
+      "resolved": "https://registry.npmjs.org/node-tkms/-/node-tkms-0.13.20-0.tgz",
+      "integrity": "sha512-oS1gKzQEXDfrsk5fR6qCUVFNAVI+avKOcaP6suK7zEYy+lTIZUylBnnbHTZjrhmSQ1jqMg09pUA11l1x3Ls9FA==",
       "license": "BSD-3-Clause-Clear"
     },
     "node_modules/normalize-path": {
@@ -11780,9 +11780,9 @@
       }
     },
     "node_modules/tfhe": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/tfhe/-/tfhe-1.5.4.tgz",
-      "integrity": "sha512-hN1RWB95BsCjIxVMWHAVhFyM45+qsufHCpPhTYOwoTlsHNh9KwrRZsc4aNts+BOc8EEf/GT7DajA+STR4xRhTg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/tfhe/-/tfhe-1.6.1.tgz",
+      "integrity": "sha512-TV0mBKzOjySSaxM+y05NWnKdkR0E8Sscu+dOg2vEYPpAUM9+rG8/e3kmurQ23+zTp9bcHKWUjGtVKChCnZXr4A==",
       "license": "BSD-3-Clause-Clear"
     },
     "node_modules/timers-browserify": {
@@ -11816,9 +11816,9 @@
       }
     },
     "node_modules/tkms": {
-      "version": "0.13.10",
-      "resolved": "https://registry.npmjs.org/tkms/-/tkms-0.13.10.tgz",
-      "integrity": "sha512-9I9Zi7wXEb3ZCKRHpr/RFTmDfNPDIFiuI8MjGOb3W74Pk8muW17DlwBaIvYXInjhIVINWPQxmWuYmluX6Rt0zg==",
+      "version": "0.13.20-0",
+      "resolved": "https://registry.npmjs.org/tkms/-/tkms-0.13.20-0.tgz",
+      "integrity": "sha512-N/KkfyHUo6bnG2UqpuWa336Zq8066rNJacmXD0UFny6eVl81srYoRa6I0HH8pkTJqU9Ho9KRU5khMrLhti9pGQ==",
       "license": "BSD-3-Clause-Clear"
     },
     "node_modules/tldts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zama-fhe/relayer-sdk",
-  "version": "0.5.0-alpha.4",
+  "version": "0.5.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zama-fhe/relayer-sdk",
-      "version": "0.5.0-alpha.4",
+      "version": "0.5.0-rc.2",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "commander": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -93,10 +93,10 @@
     "ethers": "^6.15.0",
     "fetch-retry": "^6.0.0",
     "keccak": "^3.0.4",
-    "node-tfhe": "1.5.4",
-    "node-tkms": "0.13.10",
-    "tfhe": "1.5.4",
-    "tkms": "0.13.10",
+    "node-tfhe": "1.6.1",
+    "node-tkms": "0.13.20-0",
+    "tfhe": "1.6.1",
+    "tkms": "0.13.20-0",
     "wasm-feature-detect": "^1.8.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zama-fhe/relayer-sdk",
-  "version": "0.5.0-rc.1",
+  "version": "0.5.0-rc.2",
   "description": "fhevm Relayer SDK",
   "main": "lib/node.js",
   "types": "lib/node.d.ts",

--- a/src/mock/node-tkms-mock.ts
+++ b/src/mock/node-tkms-mock.ts
@@ -162,6 +162,7 @@ export function process_user_decryption_resp_from_js(
   agg_resp: any,
   enc_pk: PublicEncKeyMlKem512Mock,
   enc_sk: PrivateEncKeyMlKem512Mock,
+  threshold: number | null | undefined,
   verify: boolean,
 ): TypedPlaintextMock[] {
   return [];

--- a/src/relayer/userDecrypt.ts
+++ b/src/relayer/userDecrypt.ts
@@ -369,6 +369,7 @@ export const userDecryptRequest =
         tkmsUserDecryptResults,
         pubKey,
         privKey,
+        undefined,
         true,
       );
       const listBigIntDecryptions = decryption.map(
@@ -518,6 +519,7 @@ export const delegatedUserDecryptRequest =
         tkmsUserDecryptResults,
         pubKey,
         privKey,
+        undefined,
         true,
       );
       const listBigIntDecryptions = decryption.map(

--- a/src/sdk/lowlevel/public-api.d.ts
+++ b/src/sdk/lowlevel/public-api.d.ts
@@ -200,6 +200,7 @@ export interface TKMSType {
     agg_resp: any,
     enc_pk: WasmObject,
     enc_sk: WasmObject,
+    threshold: number | null | undefined,
     verify: boolean,
   ): TypedPlaintextWasmType[];
   ml_kem_pke_keygen(): WasmObject;


### PR DESCRIPTION
This PR bumps `tkms` to v0.13.20-0, `tfhe` to v1.6.1 (and both corresponding `node` versions) and also sets the relayer-sdk version to v0.5.0-rc.2
This is for compatibility with fhevm v0.13