### PR TITLE
fix: normalize relayer response bytes

### DIFF
--- a/src/base/fetch.test.ts
+++ b/src/base/fetch.test.ts
@@ -35,8 +35,23 @@ describe('fetchBytes', () => {
 
   //////////////////////////////////////////////////////////////////////////////
 
-  it('fetches bytes using bytes method when available', async () => {
+  it('normalizes bytes method output when it returns an ArrayBuffer', async () => {
     const testData = new Uint8Array([1, 2, 3, 4, 5]);
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      bytes: jest.fn().mockResolvedValue(testData.buffer),
+    });
+
+    const response = await fetch('https://example.com/data');
+    const result = await getResponseBytes(response);
+
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result).toEqual(testData);
+  });
+
+  it('normalizes bytes method output when it returns an ArrayBufferView', async () => {
+    const buffer = new Uint8Array([0, 1, 2, 3, 4, 5]).buffer;
+    const testData = new DataView(buffer, 1, 4);
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       bytes: jest.fn().mockResolvedValue(testData),
@@ -45,7 +60,8 @@ describe('fetchBytes', () => {
     const response = await fetch('https://example.com/data');
     const result = await getResponseBytes(response);
 
-    expect(result).toEqual(testData);
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result).toEqual(new Uint8Array([1, 2, 3, 4]));
   });
 });
 

--- a/src/relayer-provider/v1/networkV1.ts
+++ b/src/relayer-provider/v1/networkV1.ts
@@ -11,6 +11,7 @@ import {
 } from '@sdk/lowlevel/constants';
 import { fetchRelayerV1Get } from './fetchRelayerV1';
 import { isNonEmptyString, removeSuffix } from '@base/string';
+import { getResponseBytes } from '@base/fetch';
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type CachedKey = {
@@ -77,13 +78,7 @@ export async function getKeysFromRelayer(
       );
     }
 
-    let publicKey: Uint8Array;
-    if (typeof publicKeyResponse.bytes === 'function') {
-      // bytes is not widely supported yet
-      publicKey = await publicKeyResponse.bytes();
-    } else {
-      publicKey = new Uint8Array(await publicKeyResponse.arrayBuffer());
-    }
+    const publicKey = await getResponseBytes(publicKeyResponse);
 
     const publicParamsUrl = data.response.crs['2048'].urls[0];
     const publicParamsId = data.response.crs['2048'].data_id;
@@ -95,15 +90,7 @@ export async function getKeysFromRelayer(
       );
     }
 
-    let publicParams2048: Uint8Array;
-    if (typeof publicParams2048Response.bytes === 'function') {
-      // bytes is not widely supported yet
-      publicParams2048 = await publicParams2048Response.bytes();
-    } else {
-      publicParams2048 = new Uint8Array(
-        await publicParams2048Response.arrayBuffer(),
-      );
-    }
+    const publicParams2048 = await getResponseBytes(publicParams2048Response);
 
     let pub_key;
     try {


### PR DESCRIPTION
## Summary
- reuse `getResponseBytes` in the v1 relayer key fetch path so `Response.bytes()` outputs are normalized before TFHE deserialization
- add regression coverage for runtimes where `bytes()` returns an `ArrayBuffer` or another `ArrayBufferView`

Fixes #378.

## Verification
- `npx jest --colors --passWithNoTests src/base/fetch.test.ts --runInBand --coverage=false`
- `npm run build:strict`