### PR TITLE
fix: surface relayer/edge error messages on 401 and 403

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zama-fhe/relayer-sdk",
-  "version": "0.5.0-rc.2",
+  "version": "0.5.0-rc.1",
   "description": "fhevm Relayer SDK",
   "main": "lib/node.js",
   "types": "lib/node.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zama-fhe/relayer-sdk",
-  "version": "0.5.0-rc.1",
+  "version": "0.5.0-rc.2",
   "description": "fhevm Relayer SDK",
   "main": "lib/node.js",
   "types": "lib/node.d.ts",

--- a/src/_version.ts
+++ b/src/_version.ts
@@ -1,3 +1,3 @@
 // This file is auto-generated
-export const version: string = '0.5.0-alpha.3';
+export const version: string = '0.5.0-rc.1';
 export const sdkName: string = '@zama-fhe/relayer-sdk';

--- a/src/relayer-provider/v2/RelayerV2AsyncRequest.test.ts
+++ b/src/relayer-provider/v2/RelayerV2AsyncRequest.test.ts
@@ -383,3 +383,75 @@ describeIfFetchMock('RelayerV2AsyncRequest - Auth on GET requests', () => {
     expect(getHeaders['x-api-key']).toBeUndefined();
   });
 });
+
+////////////////////////////////////////////////////////////////////////////////
+// Auth error message surfacing (401 / 403)
+////////////////////////////////////////////////////////////////////////////////
+
+describeIfFetchMock('RelayerV2AsyncRequest - auth error surfacing', () => {
+  beforeEach(() => {
+    fetchMock.removeRoutes();
+    fetchMock.callHistory.clear();
+  });
+
+  afterAll(async () => {
+    await fetchMock.callHistory.flush(true);
+  });
+
+  it('v2: 401 surfaces the relayer-provided error message', async () => {
+    fetchMock.post(requestUrl, {
+      status: 401,
+      body: {
+        error: {
+          label: 'unauthorized',
+          message: 'API key not passed via x-api-key header',
+        },
+      },
+    });
+
+    const relayerRequest = new RelayerV2AsyncRequest({
+      relayerOperation: 'INPUT_PROOF',
+      url: requestUrl,
+      payload,
+    });
+
+    await expect(relayerRequest.run()).rejects.toThrow(
+      'API key not passed via x-api-key header',
+    );
+  });
+
+  it('v2: 403 (edge/gateway) surfaces the provided error message', async () => {
+    // Cloudflare/Kong style flat `{ message, label }` body.
+    fetchMock.post(requestUrl, {
+      status: 403,
+      body: {
+        message: 'Unauthorized. Missing or invalid Zama API Key',
+        label: 'unauthorized',
+      },
+    });
+
+    const relayerRequest = new RelayerV2AsyncRequest({
+      relayerOperation: 'INPUT_PROOF',
+      url: requestUrl,
+      payload,
+    });
+
+    await expect(relayerRequest.run()).rejects.toThrow(
+      'Unauthorized. Missing or invalid Zama API Key',
+    );
+  });
+
+  it('v2: 401 without a body falls back to the default message', async () => {
+    fetchMock.post(requestUrl, { status: 401 });
+
+    const relayerRequest = new RelayerV2AsyncRequest({
+      relayerOperation: 'INPUT_PROOF',
+      url: requestUrl,
+      payload,
+    });
+
+    await expect(relayerRequest.run()).rejects.toThrow(
+      'Unauthorized, missing or invalid Zama Fhevm API Key.',
+    );
+  });
+});

--- a/src/relayer-provider/v2/RelayerV2AsyncRequest.ts
+++ b/src/relayer-provider/v2/RelayerV2AsyncRequest.ts
@@ -577,7 +577,6 @@ export class RelayerV2AsyncRequest {
         }
         // RelayerV2ResponseFailed
         // RelayerV2ApiError429
-        // falls through
         case 429: {
           // Retry
           // Rate Limit error (Cloudflare/Kong/Relayer), reason in message
@@ -954,7 +953,6 @@ export class RelayerV2AsyncRequest {
           // not recognised as terminating).
           break;
         }
-        // falls through
         case 404: {
           // Abort
           // Wrong jobId, incorrect format or unknown value etc.

--- a/src/relayer-provider/v2/RelayerV2AsyncRequest.ts
+++ b/src/relayer-provider/v2/RelayerV2AsyncRequest.ts
@@ -1688,11 +1688,11 @@ export class RelayerV2AsyncRequest {
         return { message, label };
       }
     } catch {
-      // Body was not JSON — fall back to the raw text below.
+      // Body was not JSON — relayer/edge errors that carry a message are JSON,
+      // so there is nothing usable to surface.
     }
 
-    // Truncate to keep the surfaced error readable.
-    return { message: text.slice(0, 512) };
+    return {};
   }
 
   /**

--- a/src/relayer-provider/v2/RelayerV2AsyncRequest.ts
+++ b/src/relayer-provider/v2/RelayerV2AsyncRequest.ts
@@ -55,7 +55,11 @@ import {
   assertIsRelayerV2GetResponseQueued,
   assertIsRelayerV2PostResponseQueued,
 } from './guards/RelayerV2ResponseQueued';
-import { isNonEmptyString, safeJSONstringify } from '@base/string';
+import {
+  isNonEmptyString,
+  isRecordStringProperty,
+  safeJSONstringify,
+} from '@base/string';
 import { sdkName, version } from '../../_version';
 import { RelayerV2TimeoutError } from './errors/RelayerV2TimeoutError';
 import { RelayerV2AbortError } from './errors/RelayerV2AbortError';
@@ -483,6 +487,13 @@ export class RelayerV2AsyncRequest {
 
       // At this stage: `terminated` is guaranteed to be `false`.
 
+      // 403 is not part of the relayer's typed response set — it is an
+      // edge/gateway rejection (e.g. Cloudflare/Kong). Surface its body message
+      // before narrowing to the relayer status union.
+      if (response.status === 403) {
+        await this._throwForbiddenError(response);
+      }
+
       const responseStatus: RelayerV2PostResponseStatus =
         response.status as RelayerV2PostResponseStatus;
 
@@ -558,7 +569,11 @@ export class RelayerV2AsyncRequest {
         // RelayerV2ApiError401
         // falls through
         case 401: {
-          this._throwUnauthorizedError(responseStatus);
+          await this._throwUnauthorizedError(response, responseStatus);
+          // `_throwUnauthorizedError` always throws; `break` only satisfies the
+          // compiler's switch fallthrough check (awaiting a `Promise<never>` is
+          // not recognised as terminating).
+          break;
         }
         // RelayerV2ResponseFailed
         // RelayerV2ApiError429
@@ -706,6 +721,13 @@ export class RelayerV2AsyncRequest {
       const response = await this._fetchGet();
 
       // At this stage: `terminated` is guaranteed to be `false`.
+
+      // 403 is not part of the relayer's typed response set — it is an
+      // edge/gateway rejection (e.g. Cloudflare/Kong). Surface its body message
+      // before narrowing to the relayer status union.
+      if (response.status === 403) {
+        await this._throwForbiddenError(response);
+      }
 
       const responseStatus: RelayerV2GetResponseStatus =
         response.status as RelayerV2GetResponseStatus;
@@ -926,7 +948,11 @@ export class RelayerV2AsyncRequest {
         }
         // falls through
         case 401: {
-          this._throwUnauthorizedError(responseStatus);
+          await this._throwUnauthorizedError(response, responseStatus);
+          // `_throwUnauthorizedError` always throws; `break` only satisfies the
+          // compiler's switch fallthrough check (awaiting a `Promise<never>` is
+          // not recognised as terminating).
+          break;
         }
         // falls through
         case 404: {
@@ -1578,16 +1604,95 @@ export class RelayerV2AsyncRequest {
    * Throws an unauthorized error for 401 responses.
    * @throws {RelayerV2ResponseApiError} Always throws with 'unauthorized' label.
    */
-  private _throwUnauthorizedError(
+  private async _throwUnauthorizedError(
+    response: Response,
     status: Extract<RelayerFailureStatus, 401>,
-  ): never {
+  ): Promise<never> {
+    // Surface the message provided by the relayer or an intermediary
+    // (e.g. Kong) instead of assuming the reason for the 401.
+    const { message } = await this._readResponseErrorMessage(response);
     this._throwRelayerV2ResponseApiError({
       status,
       relayerApiError: {
         label: 'unauthorized',
-        message: 'Unauthorized, missing or invalid Zama Fhevm API Key.',
+        message: isNonEmptyString(message)
+          ? message
+          : 'Unauthorized, missing or invalid Zama Fhevm API Key.',
       },
     });
+  }
+
+  /**
+   * Throws a 403 error.
+   *
+   * 403 is not part of the relayer's typed response set — it indicates the
+   * request was blocked by an edge/gateway (e.g. Cloudflare or Kong) before
+   * reaching the relayer, most commonly because of a missing or invalid
+   * `x-api-key` header. Surface the message provided by the intermediary
+   * instead of a generic "unexpected status".
+   * @throws {RelayerV2ResponseStatusError} Always throws.
+   */
+  private async _throwForbiddenError(response: Response): Promise<never> {
+    const { message } = await this._readResponseErrorMessage(response);
+    throw new RelayerV2ResponseStatusError({
+      fetchMethod: this._fetchMethod!,
+      status: 403,
+      url: this._url,
+      jobId: this._jobId,
+      operation: this._relayerOperation,
+      elapsed: this._elapsed,
+      retryCount: this._retryCount,
+      state: { ...this._state },
+      ...(isNonEmptyString(message) ? { details: message } : {}),
+    });
+  }
+
+  /**
+   * Best-effort extraction of the error message and label provided by the
+   * relayer or an intermediary (e.g. Cloudflare or Kong). The body may be a
+   * relayer JSON error (`{ error: { message, label } }`), a flat
+   * `{ message, label }`, or plain text. Never throws — returns `{}` when
+   * nothing usable can be read.
+   */
+  private async _readResponseErrorMessage(
+    response: Response,
+  ): Promise<{ message?: string | undefined; label?: string | undefined }> {
+    let text: string;
+    try {
+      text = await response.text();
+    } catch {
+      return {};
+    }
+
+    if (!isNonEmptyString(text)) {
+      return {};
+    }
+
+    try {
+      const json: unknown = JSON.parse(text);
+      // Relayer errors are nested under `error`; edge/gateway errors
+      // (Cloudflare/Kong) are usually flat `{ message, label }`.
+      const err: unknown =
+        typeof json === 'object' && json !== null && 'error' in json
+          ? (json as { error: unknown }).error
+          : json;
+
+      const message = isRecordStringProperty(err, 'message')
+        ? err.message
+        : undefined;
+      const label = isRecordStringProperty(err, 'label')
+        ? err.label
+        : undefined;
+
+      if (message !== undefined || label !== undefined) {
+        return { message, label };
+      }
+    } catch {
+      // Body was not JSON — fall back to the raw text below.
+    }
+
+    // Truncate to keep the surfaced error readable.
+    return { message: text.slice(0, 512) };
   }
 
   /**

--- a/src/relayer-provider/v2/RelayerV2Provider_keyurl.test.ts
+++ b/src/relayer-provider/v2/RelayerV2Provider_keyurl.test.ts
@@ -233,8 +233,11 @@ describeIfFetchMock('RelayerV2Provider', () => {
         'Expected fetchGetKeyUrl to throw an error, but it did not.',
       );
     } catch (e) {
-      // Error message
-      expect(String(e)).toStrictEqual('Error: HTTP error! status: 404');
+      // Error message — the message provided by the relayer/intermediary
+      // (here Kong's "no Route matched with those values") is now surfaced.
+      expect(String(e)).toStrictEqual(
+        'Error: HTTP error! status: 404 no Route matched with those values',
+      );
 
       // Error cause
       const cause = getErrorCause(e) as any;

--- a/src/relayer-provider/v2/errors/RelayerV2ResponseStatusError.ts
+++ b/src/relayer-provider/v2/errors/RelayerV2ResponseStatusError.ts
@@ -15,6 +15,11 @@ export type RelayerV2ResponseStatusErrorType = RelayerV2ResponseStatusError & {
 export type RelayerV2ResponseStatusErrorParams = Prettify<
   Omit<RelayerV2ResponseErrorBaseParams, keyof RelayerErrorBaseParams> & {
     state: RelayerV2AsyncRequestState;
+    /**
+     * Optional message provided by the relayer or an intermediary
+     * (e.g. Cloudflare/Kong) for the unexpected status, surfaced as `Details:`.
+     */
+    details?: string | undefined;
   }
 >;
 

--- a/src/relayer/error.ts
+++ b/src/relayer/error.ts
@@ -1,5 +1,6 @@
 import type { RelayerOperation } from '@relayer-provider/types/public-api';
 import type { RelayerV1ProviderErrorCause } from '@relayer-provider/v1/types';
+import { isNonEmptyString, isRecordStringProperty } from '@base/string';
 
 export function getErrorCause(e: unknown): object | undefined {
   if (e instanceof Error && typeof e.cause === 'object' && e.cause !== null) {
@@ -52,6 +53,13 @@ export async function throwRelayerResponseError(
   operation: RelayerOperation,
   response: Response,
 ): Promise<never> {
+  // Read the body once, up front, so we can both preserve it in the error cause
+  // and surface any message the relayer or an intermediary (e.g. Cloudflare or
+  // Kong) provided — instead of assuming the reason for the failure. This
+  // matters for auth failures: e.g. a 403 edge block for a missing `x-api-key`
+  // header carries a useful message that was previously discarded.
+  const { responseJson, serverMessage } = await readRelayerErrorBody(response);
+
   let message: string;
 
   // Special case for 429
@@ -72,18 +80,15 @@ export async function throwRelayerResponseError(
         break;
       }
       default: {
-        const responseText = await response.text();
-        message = `Relayer didn't response correctly. Bad status ${response.statusText}. Content: ${responseText}`;
+        message = `Relayer didn't response correctly. Bad status ${response.statusText}.`;
         break;
       }
     }
   }
 
-  let responseJson;
-  try {
-    responseJson = await response.json();
-  } catch {
-    responseJson = '';
+  // Surface the relayer/intermediary message when present.
+  if (isNonEmptyString(serverMessage)) {
+    message = `${message} ${serverMessage}`;
   }
 
   const cause: RelayerV1ProviderErrorCause = {
@@ -99,6 +104,47 @@ export async function throwRelayerResponseError(
   throw new Error(message, {
     cause,
   });
+}
+
+/**
+ * Best-effort read of a relayer error response body. Returns the parsed JSON
+ * (or raw text) for the error cause, plus the message provided by the relayer
+ * or an intermediary (Cloudflare/Kong). The body may be a relayer JSON error
+ * (`{ error: { message } }`), a flat `{ message }`, or plain text. Never throws.
+ */
+async function readRelayerErrorBody(
+  response: Response,
+): Promise<{ responseJson: unknown; serverMessage: string | undefined }> {
+  let responseText = '';
+  try {
+    responseText = await response.text();
+  } catch {
+    return { responseJson: '', serverMessage: undefined };
+  }
+
+  if (!isNonEmptyString(responseText)) {
+    return { responseJson: '', serverMessage: undefined };
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(responseText);
+    // Relayer errors may be nested under `error`; edge/gateway errors
+    // (Cloudflare/Kong) are usually flat `{ message, label }`.
+    const err: unknown =
+      typeof parsed === 'object' && parsed !== null && 'error' in parsed
+        ? (parsed as { error: unknown }).error
+        : parsed;
+    const serverMessage = isRecordStringProperty(err, 'message')
+      ? err.message
+      : undefined;
+    return { responseJson: parsed, serverMessage };
+  } catch {
+    // Body was not JSON — surface the raw text (truncated to stay readable).
+    return {
+      responseJson: responseText,
+      serverMessage: responseText.slice(0, 512),
+    };
+  }
 }
 
 export function throwRelayerJSONError(

--- a/src/relayer/error.ts
+++ b/src/relayer/error.ts
@@ -139,11 +139,9 @@ async function readRelayerErrorBody(
       : undefined;
     return { responseJson: parsed, serverMessage };
   } catch {
-    // Body was not JSON — surface the raw text (truncated to stay readable).
-    return {
-      responseJson: responseText,
-      serverMessage: responseText.slice(0, 512),
-    };
+    // Body was not JSON — relayer/edge errors that carry a message are JSON,
+    // so preserve the previous behaviour (no surfaced message, empty cause).
+    return { responseJson: '', serverMessage: undefined };
   }
 }
 


### PR DESCRIPTION
## Problem

The relayer SDK assumes it knows why a 401/403 occurred and never passes through the message returned by the relayer, Kong, or Cloudflare. (Reported by Ankur — the message Cloudflare/Kong emit is never surfaced to the user.)

Two code paths discarded the message:

1. **`RelayerV2AsyncRequest`** (V2 input-proof/decrypt engine):
   - **401** → `_throwUnauthorizedError()` hardcoded `"Unauthorized, missing or invalid Zama Fhevm API Key."` and **never read the body**.
   - **403** → not handled. `response.status as ...` is only a cast, so a 403 fell through to `default` → `"Unexpected response status 403"`, discarding the body. This is exactly the Cloudflare/Kong edge-block case (e.g. missing `x-api-key`), whose body carries `{ message, label }`.

2. **`src/relayer/error.ts` → `throwRelayerResponseError`** — used by `AbstractRelayerProvider` for the keyurl GET on both providers. It built a generic `"HTTP error! status: <code>"` and discarded the body.

Other statuses (400/404/429/500/503) in the V2 engine already surfaced `message`+`label`.

## Change

- New best-effort body reader (both paths): relayer JSON (`{ error: { message, label } }`), flat `{ message, label }` (Cloudflare/Kong), or plain text; never throws.
- **V2 engine:** 401 surfaces the server message (falls back to the canned string only when the body is empty); 403 surfaces the edge/gateway message via the error `Details:` line. No public type changes — 403 is intercepted before the typed status switch; `RelayerV2ResponseStatusError` gains an optional `details`.
- **Shared fetch-error path:** appends the relayer/intermediary message to the thrown error, still preserving the parsed body in the error `cause`.

## Tests

- V2: 401-with-message, 403-with-message, 401 empty-body fallback.
- keyurl 404 + Kong-body now asserts the surfaced `"no Route matched with those values"` message (previously discarded).

## Verification

- `build:strict:relayer-provider` ✅ · `tsc:ts:test` ✅
- Full `src/relayer-provider/` suite: 29 suites, 149 passed / 7 skipped ✅

## Companion

`release/0.4.x` backport (the v0.4.4 line, where mainnet uses V1): #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)